### PR TITLE
bump version for new gem build + push

### DIFF
--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_version.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_version.rb
@@ -1,7 +1,7 @@
 module Proxy
   module Dns
     module Infoblox
-      VERSION = '0.0.3'
+      VERSION = '0.0.4'
     end
   end
 end


### PR DESCRIPTION
Jump bumps up gem version string so a new gem can be built/pushed to rubygems.org
