### PR TITLE
dns_server and infoblox_host can/should be disjoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,3 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
-

--- a/config/dns_infoblox.yml.example
+++ b/config/dns_infoblox.yml.example
@@ -6,3 +6,4 @@
 :username: "infoblox"
 :password: "infoblox"
 :dns_server: "infoblox.my.domain"
+:infoblox_host: 'infoblox.my.domain'

--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
@@ -9,7 +9,7 @@ module Proxy::Dns::Infoblox
     end
 
     def create_a_record(fqdn, ip)
-      case a_record_conflicts(fqdn, ip) #returns -1, 0, 1
+      case a_record_conflicts(fqdn.to_s, ip.to_s) #returns -1, 0, 1
       when 1
         raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
       when 0 then
@@ -20,7 +20,7 @@ module Proxy::Dns::Infoblox
     end
 
     def create_ptr_record(fqdn, ptr)
-      case ptr_record_conflicts(fqdn, ptr_to_ip(ptr)) #returns -1, 0, 1
+      case ptr_record_conflicts(fqdn.to_s, ptr_to_ip(ptr).to_s) #returns -1, 0, 1
       when 1
         raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
       when 0 then

--- a/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
+++ b/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
@@ -12,7 +12,7 @@ module Proxy::Dns::Infoblox
                                       ::Infoblox.wapi_version = '2.0'
                                       ::Infoblox::Connection.new(:username => settings[:username],
                                                                  :password => settings[:password],
-                                                                 :host => settings[:dns_server],
+                                                                 :host => settings[:infoblox_host],
                                                                  :ssl_opts => {:verify => false})
                                     end)
       container_instance.dependency :dns_provider,


### PR DESCRIPTION
Ran into the case where my gridmanagers != a dns server. This was causing the conflict checks to timeout and fail. This fix adds a config value for :infoblox_host: which will be used for the API connection (and :dns_server: remains for the dns resolver). 

Also force sending the conflict check the fqdn/ip as strings since it expects them. 
