### PR TITLE
Don't break on older versions of the Infoblox gem

### DIFF
--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
@@ -48,14 +48,23 @@ module Proxy::Dns::Infoblox
 
     def ib_create_ptr_record(ptr, fqdn)
       ip = IPAddr.new(ptr_to_ip(ptr))
-      ib_create(Infoblox::Ptr, :ptrdname => fqdn,
-                               :ipv4addr => (ip.ipv4? && ip.to_s || nil),
-                               :ipv6addr => (ip.ipv6? && ip.to_s || nil))
+
+      params = {
+        :ptrdname => fqdn,
+        :name => ptr
+      }
+      params["ipv#{ip.ipv4? ? 4 : 6}addr".to_sym] = ip.to_s
+
+      ib_create(Infoblox::Ptr, params)
     end
 
     def ib_remove_ptr_record(ptr)
       ip = IPAddr.new(ptr_to_ip(ptr))
-      ib_delete(Infoblox::Ptr, :ipv4addr => (ip.ipv4? && ip.to_s || nil), :ipv6addr => (ip.ipv6? && ip.to_s || nil))
+
+      params = {}
+      params["ipv#{ip.ipv4? ? 4 : 6}addr".to_sym] = ip.to_s
+
+      ib_delete(Infoblox::Ptr, params)
     end
 
     def ib_create(clazz, params)

--- a/test/infoblox_test.rb
+++ b/test/infoblox_test.rb
@@ -42,7 +42,7 @@ class InfobloxTest < Test::Unit::TestCase
     ptr = '1.1.1.10.in-addr.arpa'
     ip = '10.1.1.1'
 
-    @provider.expects(:ib_create).with(Infoblox::Ptr, :ptrdname => fqdn, :ipv4addr => ip, :ipv6addr => nil)
+    @provider.expects(:ib_create).with(Infoblox::Ptr, :name => ptr, :ptrdname => fqdn, :ipv4addr => ip)
     @provider.do_create(ptr, fqdn, 'PTR')
   end
 
@@ -51,7 +51,7 @@ class InfobloxTest < Test::Unit::TestCase
     ptr = '8.0.0.0.7.0.0.0.6.0.0.0.5.0.0.0.4.0.0.0.3.0.0.0.2.0.0.0.1.0.0.0.ip6.arpa'
     ip = '1:2:3:4:5:6:7:8'
 
-    @provider.expects(:ib_create).with(Infoblox::Ptr, :ptrdname => fqdn, :ipv4addr => nil, :ipv6addr => ip)
+    @provider.expects(:ib_create).with(Infoblox::Ptr, :name => ptr, :ptrdname => fqdn, :ipv6addr => ip)
     @provider.do_create(ptr, fqdn, 'PTR')
   end
 
@@ -80,7 +80,7 @@ class InfobloxTest < Test::Unit::TestCase
     ptr = '1.1.1.10.in-addr.arpa'
     ip = '10.1.1.1'
 
-    @provider.expects(:ib_delete).with(Infoblox::Ptr, :ipv4addr => ip, :ipv6addr => nil)
+    @provider.expects(:ib_delete).with(Infoblox::Ptr, :ipv4addr => ip)
     @provider.do_remove(ptr, 'PTR')
   end
 
@@ -88,7 +88,7 @@ class InfobloxTest < Test::Unit::TestCase
     ptr = '8.0.0.0.7.0.0.0.6.0.0.0.5.0.0.0.4.0.0.0.3.0.0.0.2.0.0.0.1.0.0.0.ip6.arpa'
     ip = '1:2:3:4:5:6:7:8'
 
-    @provider.expects(:ib_delete).with(Infoblox::Ptr, :ipv4addr => nil, :ipv6addr => ip)
+    @provider.expects(:ib_delete).with(Infoblox::Ptr, :ipv6addr => ip)
     @provider.do_remove(ptr, 'PTR')
   end
 end


### PR DESCRIPTION
And I quite literally just realized that I've been writing this against an - as of yet - unreleased version of the Infoblox gem...

Probably best if the creation and deletion of Ptr records works on current (and older) versions of the Infoblox gem too.
Sorry.