### PR TITLE
New feature : allow to specify a view

### DIFF
--- a/config/dns_infoblox.yml.example
+++ b/config/dns_infoblox.yml.example
@@ -6,3 +6,4 @@
 :username: "infoblox"
 :password: "infoblox"
 :dns_server: "infoblox.my.domain"
+:view: "default"

--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
@@ -3,7 +3,7 @@ module Proxy::Dns::Infoblox
     attr_reader :connection
 
     def initialize(host, connection, ttl)
-      ENV['WAPI_VERSION']='2.0'
+      ENV['WAPI_VERSION']='1.4.2'
       @connection = connection
       super(host, ttl)
     end

--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
@@ -1,6 +1,6 @@
 module Proxy::Dns::Infoblox
   class Record < ::Proxy::Dns::Record
-    attr_reader :connection
+    attr_reader :connection, :view
 
     def initialize(host, connection, ttl, view = 'default')
       ENV['WAPI_VERSION']='1.4.2'

--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
@@ -1,11 +1,11 @@
 module Proxy::Dns::Infoblox
   class Record < ::Proxy::Dns::Record
-    attr_reader :connection, :view
+    attr_reader :connection, :dns_view
 
-    def initialize(host, connection, ttl, view = 'default')
+    def initialize(host, connection, ttl, dns_view = 'default')
       ENV['WAPI_VERSION']='1.4.2'
       @connection = connection
-      @view = view
+      @dns_view = dns_view
       super(host, ttl)
     end
 
@@ -73,7 +73,7 @@ module Proxy::Dns::Infoblox
     end
 
     def ib_delete(clazz, params)
-      record = clazz.find(connection, params.merge(:_max_results => 1, :view => view)).first
+      record = clazz.find(connection, params.merge(:_max_results => 1, :view => dns_view)).first
 
       raise Proxy::Dns::NotFound, "Cannot find #{clazz.class.name} entry for #{params}" if record.nil?
       record.delete || (raise Proxy::Dns::NotFound, "Cannot find #{clazz.class.name} entry for #{params}")

--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
@@ -2,9 +2,10 @@ module Proxy::Dns::Infoblox
   class Record < ::Proxy::Dns::Record
     attr_reader :connection
 
-    def initialize(host, connection, ttl)
+    def initialize(host, connection, ttl, view = 'default')
       ENV['WAPI_VERSION']='1.4.2'
       @connection = connection
+      @view = view
       super(host, ttl)
     end
 
@@ -61,18 +62,18 @@ module Proxy::Dns::Infoblox
     def ib_remove_ptr_record(ptr)
       ip = IPAddr.new(ptr_to_ip(ptr))
 
-      params = {}
+      params = { }
       params["ipv#{ip.ipv4? ? 4 : 6}addr".to_sym] = ip.to_s
 
       ib_delete(Infoblox::Ptr, params)
     end
 
     def ib_create(clazz, params)
-      clazz.new({ :connection => connection }.merge(params)).post
+      clazz.new({ :connection => connection, :view => view }.merge(params)).post
     end
 
     def ib_delete(clazz, params)
-      record = clazz.find(connection, params.merge(:_max_results => 1)).first
+      record = clazz.find(connection, params.merge(:_max_results => 1, :view => view)).first
 
       raise Proxy::Dns::NotFound, "Cannot find #{clazz.class.name} entry for #{params}" if record.nil?
       record.delete || (raise Proxy::Dns::NotFound, "Cannot find #{clazz.class.name} entry for #{params}")

--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_plugin.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_plugin.rb
@@ -2,7 +2,7 @@ module Proxy::Dns::Infoblox
   class Plugin < ::Proxy::Provider
     plugin :dns_infoblox, ::Proxy::Dns::Infoblox::VERSION
 
-    default_settings :username => 'infoblox', :password => 'infoblox', :dns_server => 'infoblox.my.domain', :view => 'default'
+    default_settings :username => 'infoblox', :password => 'infoblox', :dns_server => 'infoblox.my.domain', :dns_view => 'default'
 
     requires :dns, '>= 1.12'
 

--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_plugin.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_plugin.rb
@@ -2,7 +2,7 @@ module Proxy::Dns::Infoblox
   class Plugin < ::Proxy::Provider
     plugin :dns_infoblox, ::Proxy::Dns::Infoblox::VERSION
 
-    default_settings :username => 'infoblox', :password => 'infoblox', :dns_server => 'infoblox.my.domain'
+    default_settings :username => 'infoblox', :password => 'infoblox', :dns_server => 'infoblox.my.domain', :view => 'default'
 
     requires :dns, '>= 1.12'
 

--- a/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
+++ b/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
@@ -20,7 +20,7 @@ module Proxy::Dns::Infoblox
                                         settings[:dns_server],
                                         container_instance.get_dependency(:connection),
                                         settings[:dns_ttl],
-					settings[:dns_view]) }
+                                        settings[:dns_view]) }
     end
   end
 end

--- a/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
+++ b/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
@@ -9,7 +9,7 @@ module Proxy::Dns::Infoblox
     def load_dependency_injection_wirings(container_instance, settings)
       container_instance.dependency :connection,
                                     (lambda do
-                                      ::Infoblox.wapi_version = '2.0'
+                                      ::Infoblox.wapi_version = '1.4.2'
                                       ::Infoblox::Connection.new(:username => settings[:username],
                                                                  :password => settings[:password],
                                                                  :host => settings[:dns_server],

--- a/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
+++ b/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
@@ -19,7 +19,8 @@ module Proxy::Dns::Infoblox
                                     lambda {::Proxy::Dns::Infoblox::Record.new(
                                         settings[:dns_server],
                                         container_instance.get_dependency(:connection),
-                                        settings[:dns_ttl]) }
+                                        settings[:dns_ttl],
+					settings[:dns_view]) }
     end
   end
 end


### PR DESCRIPTION
All the record modification of Infoblox accepts an optional view parameter.
If not specified, the view selected is the default view.
In our environnement, the view to be modified is not the default view.
This modification allow to set an optional fixed view name (dns_view) to operate on.
This patch has been tested OK in our env.