### PR TITLE
Implement DNS cache cleaning on record removal

### DIFF
--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
@@ -88,7 +88,7 @@ module Proxy::Dns::Infoblox
       end
     rescue StandardError => ex
       # Failing to clear the DNS cache should never be an error
-      log.warn("Exception #{ex} was raised when clearing DNS cache")
+      logger.warn("Exception #{ex} was raised when clearing DNS cache")
     end
   end
 end

--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
@@ -74,9 +74,11 @@ module Proxy::Dns::Infoblox
       record = clazz.find(connection, params.merge(:_max_results => 1)).first
 
       raise Proxy::Dns::NotFound, "Cannot find #{clazz.class.name} entry for #{params}" if record.nil?
-      record.delete || (raise Proxy::Dns::NotFound, "Cannot find #{clazz.class.name} entry for #{params}")
+      ret_value = record.delete || (raise Proxy::Dns::NotFound, "Cannot find #{clazz.class.name} entry for #{params}")
 
       ib_clear_dns_cache(record)
+
+      ret_value
     end
 
     def ib_clear_dns_cache(record)

--- a/lib/smart_proxy_dns_infoblox/infoblox_member_dns.rb
+++ b/lib/smart_proxy_dns_infoblox/infoblox_member_dns.rb
@@ -1,0 +1,19 @@
+module Proxy::Dns::Infoblox
+  class MemberDns < Infoblox::Resource
+    remote_attr_reader :host_name
+
+    wapi_object 'member:dns'
+
+    def clear_dns_cache(clear_full_tree: false,
+                       domain: nil,
+                       view: nil)
+      post_body = {
+        clear_full_tree: clear_full_tree
+      }
+      post_body[:domain] = domain unless domain.nil?
+      post_body[:view] = view unless view.nil?
+
+      JSON.parse(connection.post(resource_uri + "?_function=clear_dns_cache", post_body).body)
+    end
+  end
+end

--- a/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
+++ b/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
@@ -4,6 +4,7 @@ module Proxy::Dns::Infoblox
       require 'infoblox'
       require 'dns_common/dns_common'
       require 'smart_proxy_dns_infoblox/dns_infoblox_main'
+      require 'smart_proxy_dns_infoblox/infoblox_member_dns'
     end
 
     def load_dependency_injection_wirings(container_instance, settings)

--- a/test/infoblox_test.rb
+++ b/test/infoblox_test.rb
@@ -97,11 +97,14 @@ class InfobloxTest < Test::Unit::TestCase
     record = Infoblox::Arecord.new name: fqdn
     record.stubs(:delete).returns(record)
 
+    old_version = Infoblox.wapi_version 
     Infoblox.wapi_version = '2.0'
 
     Infoblox::Arecord.expects(:find).returns([record])
     Proxy::Dns::Infoblox::MemberDns.expects(:all).never
     @provider.do_remove(fqdn, 'A')
+  ensure
+    Infoblox.wapi_version = old_version
   end
 
   def test_wapi_new
@@ -110,11 +113,14 @@ class InfobloxTest < Test::Unit::TestCase
     record.stubs(:delete).returns(record)
     member = Proxy::Dns::Infoblox::MemberDns.new name: 'ns1.example.com'
 
+    old_version = Infoblox.wapi_version 
     Infoblox.wapi_version = '2.7'
 
     Infoblox::Arecord.expects(:find).returns([record])
     Proxy::Dns::Infoblox::MemberDns.expects(:all).returns([member])
     member.expects(:clear_dns_cache).with(view: 'test', domain: fqdn)
     @provider.do_remove(fqdn, 'A')
+  ensure
+    Infoblox.wapi_version = old_version
   end
 end

--- a/test/infoblox_test.rb
+++ b/test/infoblox_test.rb
@@ -97,7 +97,7 @@ class InfobloxTest < Test::Unit::TestCase
     record = Infoblox::Arecord.new name: fqdn
     record.stubs(:delete).returns(record)
 
-    old_version = Infoblox.wapi_version 
+    old_version = Infoblox.wapi_version
     Infoblox.wapi_version = '2.0'
 
     Infoblox::Arecord.expects(:find).returns([record])
@@ -113,7 +113,7 @@ class InfobloxTest < Test::Unit::TestCase
     record.stubs(:delete).returns(record)
     member = Proxy::Dns::Infoblox::MemberDns.new name: 'ns1.example.com'
 
-    old_version = Infoblox.wapi_version 
+    old_version = Infoblox.wapi_version
     Infoblox.wapi_version = '2.7'
 
     Infoblox::Arecord.expects(:find).returns([record])


### PR DESCRIPTION
WAPI version 2.6 and newer exposes the DNS cache clearing feature in InfoBlox, this patch makes use of that feature to ensure that caches are cleared when entries are removed.