### PR TITLE
Pin bundler for Ruby 2.0 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ rvm:
   - 2.4
   - 2.5
 before_install:
-  - gem update --system
-  - gem install bundler
+  - gem install bundler -v 1.17.3
 sudo: false
 cache: bundler
 


### PR DESCRIPTION
Bundler requires modern Ruby versions now, let's stay on 2.0 because that's proxy version for now.