### PR TITLE
Added dns_view config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Example installation command via foreman-installer:
 --foreman-proxy-dns-provider infoblox \
 --foreman-proxy-plugin-dns-infoblox-dns-server 192.168.201.2 \
 --foreman-proxy-plugin-dns-infoblox-username admin \
---foreman-proxy-plugin-dns-infoblox-password infoblox
+--foreman-proxy-plugin-dns-infoblox-password infoblox \
+--foreman-proxy-plugin-dns-infoblox-dns-view default
 ```
 
 ## Configuration
@@ -27,9 +28,7 @@ To enable this DNS provider, edit `/etc/foreman-proxy/settings.d/dns.yml` and se
 
     :use_provider: dns_infoblox
 
-Configuration options for this plugin are in `/etc/foreman-proxy/settings.d/dns_infoblox.yml` and include:
-
-* example_setting: change this as an example
+Configuration options for this plugin are in `/etc/foreman-proxy/settings.d/dns_infoblox.yml`, see the [example configuration file](config/dns_infoblox.yml.example) for more details.
 
 ## SSL
 
@@ -74,7 +73,7 @@ Fork and send a Pull Request. Thanks!
 
 ## Copyright
 
-Copyright (c) *year* *your name*
+Copyright (c) 2018 Red Hat
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/config/dns_infoblox.yml.example
+++ b/config/dns_infoblox.yml.example
@@ -1,8 +1,12 @@
 ---
-#
-# Configuration file for 'infoblox dns provider
-#
+# Configuration file for 'dns_infoblox' dhcp provider
 
-:username: "infoblox"
+# Credentials for Infoblox API, make sure the DNS Role is assigned
+:username: "admin"
 :password: "infoblox"
-:dns_server: "infoblox.my.domain"
+
+# Hostname or IP address of the Infoblox appliance (without https:// or port)
+:dns_server: "infoblox.example.com"
+
+# View used for records, usually 'default.myview' for custom names.
+#:dns_view: 'default'

--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
@@ -1,9 +1,10 @@
 module Proxy::Dns::Infoblox
   class Record < ::Proxy::Dns::Record
-    attr_reader :connection
+    attr_reader :connection, :dns_view
 
-    def initialize(host, connection, ttl)
+    def initialize(host, connection, ttl, dns_view)
       @connection = connection
+      @dns_view = dns_view
       super(host, ttl)
     end
 
@@ -67,11 +68,11 @@ module Proxy::Dns::Infoblox
     end
 
     def ib_create(clazz, params)
-      clazz.new({ :connection => connection }.merge(params)).post
+      clazz.new({ connection: connection, view: dns_view }.merge(params)).post
     end
 
     def ib_delete(clazz, params)
-      record = clazz.find(connection, params.merge(:_max_results => 1)).first
+      record = clazz.find(connection, params.merge(_max_results: 1, view: dns_view)).first
 
       raise Proxy::Dns::NotFound, "Cannot find #{clazz.class.name} entry for #{params}" if record.nil?
       ret_value = record.delete || (raise Proxy::Dns::NotFound, "Cannot find #{clazz.class.name} entry for #{params}")

--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_plugin.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_plugin.rb
@@ -2,7 +2,7 @@ module Proxy::Dns::Infoblox
   class Plugin < ::Proxy::Provider
     plugin :dns_infoblox, ::Proxy::Dns::Infoblox::VERSION
 
-    default_settings :username => 'infoblox', :password => 'infoblox', :dns_server => 'infoblox.my.domain'
+    default_settings :username => 'infoblox', :password => 'infoblox', :dns_server => 'localhost', :dns_view => 'default'
 
     requires :dns, '>= 1.12'
 

--- a/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
+++ b/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
@@ -22,7 +22,8 @@ module Proxy::Dns::Infoblox
                                       ::Proxy::Dns::Infoblox::Record.new(
                                         settings[:dns_server],
                                         container_instance.get_dependency(:connection),
-                                        settings[:dns_ttl]) }
+                                        settings[:dns_ttl],
+                                        settings[:dns_view])}
     end
   end
 end

--- a/test/infoblox_test.rb
+++ b/test/infoblox_test.rb
@@ -10,7 +10,7 @@ class InfobloxTest < Test::Unit::TestCase
   end
 
   def setup
-    @provider = Proxy::Dns::Infoblox::Record.new('a_host', nil, 999)
+    @provider = Proxy::Dns::Infoblox::Record.new('a_host', nil, 999, 'default.test')
   end
 
   def test_create_a


### PR DESCRIPTION
This option is missing therefore it was not possible to do DNS updates in different views than the "default" one.

https://bugzilla.redhat.com/show_bug.cgi?id=1705546