### PR TITLE
Add explicit return statements

### DIFF
--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
@@ -12,12 +12,14 @@ module Proxy::Dns::Infoblox
       method = "ib_create_#{type.downcase}_record".to_sym
       raise(Proxy::Dns::Error, "Creation of #{type} records not implemented") unless respond_to?(method, true)
       send(method, name, value)
+      nil
     end
 
     def do_remove(name, type)
       method = "ib_remove_#{type.downcase}_record".to_sym
       raise(Proxy::Dns::Error, "Deletion of #{type} records not implemented") unless respond_to?(method, true)
       send(method, name)
+      nil
     end
 
     private


### PR DESCRIPTION
Foreman proxy DNS modules have a contract which require them to return return
nil value when request was processed successfully. The Infoblox DNS module does
not do that and some Infoblox instances can cause the code to return some
object (e.g. stream) which is causing the Rack stack to keep the connection
open causing HTTP stale connection causing read timeout in Foreman application.

I can't verify this fixes the issue, however check other DNS modules in Smart
Proxy - they do return `nil` explicitly. Search for method `do_create` in the
core codebase.

A nasty one, if this is confirmed by the customer I will create a warning in
the log if a module does not return `nil` value. Or we can discuss changing
this poor contract.