### PR TITLE
Refs #27046 - Resolv the DNS server IP if needed

### DIFF
--- a/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
+++ b/lib/smart_proxy_dns_infoblox/plugin_configuration.rb
@@ -1,10 +1,20 @@
 module Proxy::Dns::Infoblox
   class PluginConfiguration
     def load_classes
+      require 'ipaddr'
+      require 'resolv'
       require 'infoblox'
       require 'dns_common/dns_common'
       require 'smart_proxy_dns_infoblox/dns_infoblox_main'
       require 'smart_proxy_dns_infoblox/infoblox_member_dns'
+    end
+
+    def get_dns_server_ip(dns_server)
+      begin
+        IPAddr.new(dns_server).to_s
+      rescue IPAddr::InvalidAddressError
+        Resolv.getaddresses(dns_server).first
+      end
     end
 
     def load_dependency_injection_wirings(container_instance, settings)
@@ -20,7 +30,7 @@ module Proxy::Dns::Infoblox
       container_instance.dependency :dns_provider,
                                     lambda {
                                       ::Proxy::Dns::Infoblox::Record.new(
-                                        settings[:dns_server],
+                                        get_dns_server_ip(settings[:dns_server]),
                                         container_instance.get_dependency(:connection),
                                         settings[:dns_ttl],
                                         settings[:dns_view])}


### PR DESCRIPTION
This is an alternative implementation to 79ceedcee3bb3e334cea2f7219a8820ae44dc6dd.

The root cause of the issue is that if the DNS server is a hostname, the resolver can't find it because it has no way to get the IP address of the resolver. By using the system resolver (as the HTTP API would), we get equivalent behavior.

A minimal reproducer of what's happening:

```ruby
require 'resolv'
resolver = Resolv::DNS.new(:nameserver => 'infoblox.example.com')
resolver.getresource('host.example.org', Resolv::DNS::Resource::IN::A)
```