### PR TITLE
Fixes #27174 - REST API-based DNS conflict check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Gemfile.lock
 .ruby-*
 tags
 config/*.yml
+extra/*.local.sh

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,13 +2,16 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   TargetRubyVersion: 2.0
+  Exclude:
+    - 'extra/**/*.rb'
+    - 'vendor/**/*'
 
 # There's if statement in the Gemfile
 Bundler/DuplicatedGem:
   Enabled: false
 
-Metrics/LineLength:
-  Max: 200
+Metrics:
+  Enabled: false
 
 Layout/LeadingCommentSpace:
   Enabled: false
@@ -42,21 +45,11 @@ Style/FrozenStringLiteralComment:
 Layout/BlockEndNewline:
   Enabled: false
 
-Metrics/MethodLength:
-  Enabled: false
-
 Style/ClassAndModuleChildren:
-  Enabled: false
-
-Metrics/AbcSize:
   Enabled: false
 
 Style/SymbolArray:
   Enabled: false
-
-Metrics/ClassLength:
-  Exclude:
-    - 'test/**/*'
 
 Lint/AmbiguousRegexpLiteral:
   Enabled: false

--- a/config/dns_infoblox.yml.example
+++ b/config/dns_infoblox.yml.example
@@ -5,13 +5,8 @@
 :username: "admin"
 :password: "infoblox"
 
-# IP address of the Infoblox appliance (without https:// or port) and a DNS
-# server for conflict queries. If set to hostname, make sure this is set
-# in /etc/hosts because the module performs DNS queries against this address.
-# If this Infoblox server does not provide DNS resolver, set environmental
-# variable INFOBLOX_DNS_RESOLVER=2.3.4.5 to override this setting to do
-# DNS lookups on a different IP address. This is a temporary workaround until
-# DNS core API is modified to allow DNS conflict lookups.
+# IP address of the Infoblox appliance (without https:// or port). If set
+# to hostname, make sure it resolves correctly.
 :dns_server: "1.2.3.4"
 
 # View used for records, usually 'default.myview' for custom names.

--- a/extra/end-to-end-test.rb
+++ b/extra/end-to-end-test.rb
@@ -1,0 +1,91 @@
+require 'rest-client'
+require 'json'
+require 'pp'
+
+# subnets and domains must exist on Infoblox
+URL = ENV['FOREMAN_PROXY_URL'] || "http://localhost:8000"
+DNS_DOMAIN = ENV['IBX_DNS_DOMAIN'] || "example.com"
+DNS_IPV4 = ENV['IBX_DNS_IPV4'] || "192.0.2.1"
+DNS_IPV6 = ENV['IBX_DNS_IPV6'] || "2001:db8::1"
+DNS_PTR4 = ENV['IBX_DNS_PTR4'] || "1.2.0.192.in-addr.arpa"
+DNS_PTR6 = ENV['IBX_DNS_PTR6'] || "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa"
+
+def do_get(path)
+  RestClient.get("#{URL}#{path}")
+end
+
+def do_post(path, body = nil, params = {})
+  RestClient.post("#{URL}#{path}", body, params.merge({content_type: :json}))
+end
+
+def do_delete(path, params = {})
+  RestClient.delete("#{URL}#{path}", params.merge({content_type: :json}))
+end
+
+features = JSON.parse(do_get("/v2/features"))
+
+if features["dns"]["state"] == "running"
+  fqdn = "end2end.#{DNS_DOMAIN}"
+  cname = "alias-end2end.#{DNS_DOMAIN}"
+  puts "Performing DNS tests with #{fqdn}"
+  begin
+    do_post("/dns?type=a&fqdn=#{fqdn}&value=#{DNS_IPV4}")
+    do_post("/dns?type=a&fqdn=#{fqdn}&value=#{DNS_IPV4}") # skip (already exists)
+    begin
+      do_post("/dns?type=a&fqdn=#{fqdn}&value=192.0.2.1")
+      raise "Expected conflict not returned"
+    rescue RestClient::Conflict
+      # expected
+    end
+  ensure
+    do_delete("/dns/#{fqdn}/A")
+  end
+  begin
+    do_post("/dns?type=aaaa&fqdn=#{fqdn}&value=#{DNS_IPV6}")
+    do_post("/dns?type=aaaa&fqdn=#{fqdn}&value=#{DNS_IPV6}") # skip (already exists)
+    begin
+      do_post("/dns?type=aaaa&fqdn=#{fqdn}&value=2001:db8::2")
+      raise "Expected conflict not returned"
+    rescue RestClient::Conflict
+      # expected
+    end
+  ensure
+    do_delete("/dns/#{fqdn}/AAAA")
+  end
+  begin
+    do_post("/dns?type=cname&fqdn=#{fqdn}&value=#{cname}")
+    do_post("/dns?type=cname&fqdn=#{fqdn}&value=#{cname}") # skip (already exists)
+    begin
+      do_post("/dns?type=cname&fqdn=#{fqdn}&value=a2-#{cname}")
+      raise "Expected conflict not returned"
+    rescue RestClient::Conflict
+      # expected
+    end
+  ensure
+    do_delete("/dns/#{fqdn}/CNAME")
+  end
+  begin
+    do_post("/dns?type=ptr&fqdn=#{fqdn}&value=#{DNS_PTR4}")
+    do_post("/dns?type=ptr&fqdn=#{fqdn}&value=#{DNS_PTR4}") # skip (already exists)
+    begin
+      do_post("/dns?type=ptr&fqdn=#{fqdn}&value=14.202.168.192.in-addr.arpa")
+      raise "Expected conflict not returned"
+    rescue RestClient::Conflict
+      # expected
+    end
+  ensure
+    do_delete("/dns/#{DNS_PTR4}/PTR")
+  end
+  begin
+    do_post("/dns?type=ptr&fqdn=#{fqdn}&value=#{DNS_PTR6}")
+    do_post("/dns?type=ptr&fqdn=#{fqdn}&value=#{DNS_PTR6}") # skip (already exists)
+    begin
+      do_post("/dns?type=ptr&fqdn=#{fqdn}&value=1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.9.b.d.0.1.0.0.2.ip6.arpa")
+      raise "Expected conflict not returned"
+    rescue RestClient::Conflict
+      # expected
+    end
+  ensure
+    do_delete("/dns/#{DNS_PTR6}/PTR")
+  end
+end

--- a/test/infoblox_test.rb
+++ b/test/infoblox_test.rb
@@ -13,6 +13,74 @@ class InfobloxTest < Test::Unit::TestCase
     @provider = Proxy::Dns::Infoblox::Record.new('a_host', nil, 999, 'default.test')
   end
 
+  def test_conflict_a_ok
+    @provider.expects(:ib_find_a_record).with("test.example.com").returns([])
+    assert_equal(-1, @provider.record_conflicts_ip("test.example.com", Resolv::DNS::Resource::IN::A, "1.2.3.4"))
+  end
+
+  def test_conflict_a_already_exists
+    @provider.expects(:ib_find_a_record).with("test.example.com").returns([true])
+    @provider.expects(:ib_find_a_record).with("test.example.com", "1.2.3.4").returns([true])
+    assert_equal(0, @provider.record_conflicts_ip("test.example.com", Resolv::DNS::Resource::IN::A, "1.2.3.4"))
+  end
+
+  def test_conflict_a_conflict
+    @provider.expects(:ib_find_a_record).with("test.example.com").returns([false])
+    @provider.expects(:ib_find_a_record).with("test.example.com", "1.2.3.4").returns([false])
+    assert_equal(1, @provider.record_conflicts_ip("test.example.com", Resolv::DNS::Resource::IN::A, "1.2.3.4"))
+  end
+
+  def test_conflict_aaaa_ok
+    @provider.expects(:ib_find_aaaa_record).with("test.example.com").returns([])
+    assert_equal(-1, @provider.record_conflicts_ip("test.example.com", Resolv::DNS::Resource::IN::AAAA, "1.2.3.4"))
+  end
+
+  def test_conflict_aaaa_already_exists
+    @provider.expects(:ib_find_aaaa_record).with("test.example.com").returns([true])
+    @provider.expects(:ib_find_aaaa_record).with("test.example.com", "1.2.3.4").returns([true])
+    assert_equal(0, @provider.record_conflicts_ip("test.example.com", Resolv::DNS::Resource::IN::AAAA, "1.2.3.4"))
+  end
+
+  def test_conflict_aaaa_conflict
+    @provider.expects(:ib_find_aaaa_record).with("test.example.com").returns([false])
+    @provider.expects(:ib_find_aaaa_record).with("test.example.com", "1.2.3.4").returns([false])
+    assert_equal(1, @provider.record_conflicts_ip("test.example.com", Resolv::DNS::Resource::IN::AAAA, "1.2.3.4"))
+  end
+
+  def test_conflict_ptr_ok
+    @provider.expects(:ib_find_ptr_record).with("13.202.168.192.in-addr.arpa").returns([])
+    assert_equal(-1, @provider.record_conflicts_ip("13.202.168.192.in-addr.arpa", Resolv::DNS::Resource::IN::PTR, "test.example.com"))
+  end
+
+  def test_conflict_ptr_already_exists
+    @provider.expects(:ib_find_ptr_record).with("13.202.168.192.in-addr.arpa").returns([true])
+    @provider.expects(:ib_find_ptr_record).with("13.202.168.192.in-addr.arpa", "test.example.com").returns([true])
+    assert_equal(0, @provider.record_conflicts_ip("13.202.168.192.in-addr.arpa", Resolv::DNS::Resource::IN::PTR, "test.example.com"))
+  end
+
+  def test_conflict_ptr_conflict
+    @provider.expects(:ib_find_ptr_record).with("13.202.168.192.in-addr.arpa").returns([false])
+    @provider.expects(:ib_find_ptr_record).with("13.202.168.192.in-addr.arpa", "test.example.com").returns([false])
+    assert_equal(1, @provider.record_conflicts_ip("13.202.168.192.in-addr.arpa", Resolv::DNS::Resource::IN::PTR, "test.example.com"))
+  end
+
+  def test_conflict_cname_ok
+    @provider.expects(:ib_find_cname_record).with("test.example.com").returns([])
+    assert_equal(-1, @provider.record_conflicts_ip("test.example.com", Resolv::DNS::Resource::IN::CNAME, "alias.example.com"))
+  end
+
+  def test_conflict_cname_already_exists
+    @provider.expects(:ib_find_cname_record).with("test.example.com").returns([true])
+    @provider.expects(:ib_find_cname_record).with("test.example.com", "alias.example.com").returns([true])
+    assert_equal(0, @provider.record_conflicts_ip("test.example.com", Resolv::DNS::Resource::IN::CNAME, "alias.example.com"))
+  end
+
+  def test_conflict_cname_conflict
+    @provider.expects(:ib_find_cname_record).with("test.example.com").returns([false])
+    @provider.expects(:ib_find_cname_record).with("test.example.com", "alias.example.com").returns([false])
+    assert_equal(1, @provider.record_conflicts_ip("test.example.com", Resolv::DNS::Resource::IN::CNAME, "alias.example.com"))
+  end
+
   def test_create_a
     fqdn = 'test.example.com'
     ip = '10.1.1.1'


### PR DESCRIPTION
Instead relying on Ruby DNS resolv by common DNS module from smart-proxy core.

This took me all day of work, setting up Infoblox DNS, creating IPv6 space etc etc. I tested this end to end using a simple script, I am going to attach it to the PR.