### PR TITLE
Remove Travis testing in favor of Jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
----
-rvm:
-  - 2.0
-  - 2.6
-before_install:
-  - gem install bundler -v 1.17.3
-sudo: false
-cache: bundler
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # SmartProxyDnsInfoblox
 
-[![Build Status](https://travis-ci.org/theforeman/smart_proxy_dns_infoblox.svg?branch=master)](https://travis-ci.org/theforeman/smart_proxy_dns_infoblox)
-
 This plugin adds a new DNS provider for managing records in MyService.
 
 ## Installation


### PR DESCRIPTION
This plugin has been added to Jenkins where the Ruby versions are centrally maintained and don't need manual updating.