### PR TITLE
Separate IPv4 and v6 handling for PTR records

### DIFF
--- a/test/infoblox_test.rb
+++ b/test/infoblox_test.rb
@@ -48,20 +48,31 @@ class InfobloxTest < Test::Unit::TestCase
   end
 
   def test_conflict_ptr_ok
-    @provider.expects(:ib_find_ptr_record).with("13.202.168.192.in-addr.arpa").returns([])
-    assert_equal(-1, @provider.record_conflicts_ip("13.202.168.192.in-addr.arpa", Resolv::DNS::Resource::IN::PTR, "test.example.com"))
+    @provider.expects(:ib_find_ptr4_record).with("test.example.com").returns([])
+    assert_equal(-1, @provider.record_conflicts_name("13.202.168.192.in-addr.arpa", Resolv::DNS::Resource::IN::PTR, "test.example.com"))
+
+    @provider.expects(:ib_find_ptr6_record).with("test.example.com").returns([])
+    assert_equal(-1, @provider.record_conflicts_name("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", Resolv::DNS::Resource::IN::PTR, "test.example.com"))
   end
 
   def test_conflict_ptr_already_exists
-    @provider.expects(:ib_find_ptr_record).with("13.202.168.192.in-addr.arpa").returns([true])
-    @provider.expects(:ib_find_ptr_record).with("13.202.168.192.in-addr.arpa", "test.example.com").returns([true])
-    assert_equal(0, @provider.record_conflicts_ip("13.202.168.192.in-addr.arpa", Resolv::DNS::Resource::IN::PTR, "test.example.com"))
+    @provider.expects(:ib_find_ptr4_record).with("test.example.com").returns([true])
+    @provider.expects(:ib_find_ptr4_record).with("test.example.com", "13.202.168.192.in-addr.arpa").returns([true])
+    assert_equal(0, @provider.record_conflicts_name("13.202.168.192.in-addr.arpa", Resolv::DNS::Resource::IN::PTR, "test.example.com"))
+
+    @provider.expects(:ib_find_ptr6_record).with("test.example.com").returns([true])
+    @provider.expects(:ib_find_ptr6_record).with("test.example.com", "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa").returns([true])
+    assert_equal(0, @provider.record_conflicts_name("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", Resolv::DNS::Resource::IN::PTR, "test.example.com"))
   end
 
   def test_conflict_ptr_conflict
-    @provider.expects(:ib_find_ptr_record).with("13.202.168.192.in-addr.arpa").returns([false])
-    @provider.expects(:ib_find_ptr_record).with("13.202.168.192.in-addr.arpa", "test.example.com").returns([false])
-    assert_equal(1, @provider.record_conflicts_ip("13.202.168.192.in-addr.arpa", Resolv::DNS::Resource::IN::PTR, "test.example.com"))
+    @provider.expects(:ib_find_ptr4_record).with("test.example.com").returns([false])
+    @provider.expects(:ib_find_ptr4_record).with("test.example.com", "13.202.168.192.in-addr.arpa").returns([false])
+    assert_equal(1, @provider.record_conflicts_name("13.202.168.192.in-addr.arpa", Resolv::DNS::Resource::IN::PTR, "test.example.com"))
+
+    @provider.expects(:ib_find_ptr6_record).with("test.example.com").returns([false])
+    @provider.expects(:ib_find_ptr6_record).with("test.example.com", "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa").returns([false])
+    assert_equal(1, @provider.record_conflicts_name("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", Resolv::DNS::Resource::IN::PTR, "test.example.com"))
   end
 
   def test_conflict_cname_ok

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -41,9 +41,17 @@ class IntegrationTest < ::Test::Unit::TestCase
     assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"
   end
 
-  def test_create_ptr_record
-    @server.expects(:create_ptr_record).with("test.com", "33.33.168.192.in-addr.arpa")
+  def test_create_ptr4_record
+    @server.expects(:ib_find_ptr4_record).with('test.com').returns([])
+    @server.expects(:ib_create_ptr_record).with('33.33.168.192.in-addr.arpa', 'test.com')
     post '/', :fqdn => 'test.com', :value => '33.33.168.192.in-addr.arpa', :type => 'PTR'
+    assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"
+  end
+
+  def test_create_ptr6_record
+    @server.expects(:ib_find_ptr6_record).with('test.com').returns([])
+    @server.expects(:ib_create_ptr_record).with('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa', 'test.com')
+    post '/', :fqdn => 'test.com', :value => '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa', :type => 'PTR'
     assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"
   end
 


### PR DESCRIPTION
Infoblox only contains a single type for PTRs, which can contain either
an IPv4 or IPv6 address. So unless limiting searches for them in some
way, then an IPv4 PTR for the same FQDN as an IPv6 PTR will end up
looking like a collision.

With an additional regexp match on the PTR record name, the search can
be limited to only finding v4 (in-addr.arpa) or v6 (ip6.arpa) records.