### PR TITLE
Remove all found dns records

### DIFF
--- a/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
+++ b/lib/smart_proxy_dns_infoblox/dns_infoblox_main.rb
@@ -160,15 +160,15 @@ module Proxy::Dns::Infoblox
     end
 
     def ib_delete(clazz, params)
-      record = clazz.find(connection, params.merge(_max_results: 1, view: dns_view)).first
+      records = clazz.find(connection, params.merge(view: dns_view))
+      raise Proxy::Dns::NotFound, "Cannot find #{clazz.class.name} entry for #{params}" if records.empty?
 
-      raise Proxy::Dns::NotFound, "Cannot find #{clazz.class.name} entry for #{params}" if record.nil?
+      records.each do |record|
+        record.delete
+        ib_clear_dns_cache(record)
+      end
 
-      ret_value = record.delete || (raise Proxy::Dns::NotFound, "Cannot find #{clazz.class.name} entry for #{params}")
-
-      ib_clear_dns_cache(record)
-
-      ret_value
+      true
     end
 
     def ib_clear_dns_cache(record)

--- a/test/infoblox_test.rb
+++ b/test/infoblox_test.rb
@@ -171,6 +171,35 @@ class InfobloxTest < Test::Unit::TestCase
     @provider.do_remove(ptr, 'PTR')
   end
 
+  def test_wapi_remove_multi_a_records
+    address1 = '192.168.1.11'
+    address2 = '192.168.2.22'
+    fqdn = 'test.example.com'
+
+    record1 = Infoblox::Arecord.new name: fqdn, :ipv4addr => address1
+    record1.expects(:delete).returns(record1)
+    record2 = Infoblox::Arecord.new name: fqdn, :ipv4addr => address2
+    record2.expects(:delete).returns(record2)
+
+    Infoblox::Arecord.expects(:find).returns([record1, record2])
+    @provider.do_remove(fqdn, 'A')
+  end
+
+  def test_wapi_remove_multi_ptr_records
+    ptr = '1.1.1.10.in-addr.arpa'
+    ip = '10.1.1.1'
+    fqdn1 = 'test1.example.com'
+    fqdn2 = 'test2.example.com'
+
+    record1 = Infoblox::Ptr.new name: ptr, :ptrdname => fqdn1, :ipv4addr => ip
+    record1.expects(:delete).returns(record1)
+    record2 = Infoblox::Ptr.new name: ptr, :ptrdname => fqdn2, :ipv4addr => ip
+    record2.expects(:delete).returns(record2)
+
+    Infoblox::Ptr.expects(:find).returns([record1, record2])
+    @provider.do_remove(ptr, 'PTR')
+  end
+
   def test_wapi_old
     fqdn = 'test.example.com'
     record = Infoblox::Arecord.new name: fqdn


### PR DESCRIPTION
This is also somehow a bad dns setup but may occur on some systems which this PR does fix. Additionally, I had a look at other smart proxy dns providers and they simply delete all records and not only the first one.

Scenario:
1. Multiple DNS A records with same FQDN point to different IP addresses. 
2. Multiple DNS PTR records with same IP address point to different FQDNs. 

Especially the second issue can be fixed with this PR. Think about 2 PTR entries, one two fqdn1 and the second to fqdn2. foreman manage fqdn2 but the previous implemenation would look for only the first PTR entry matching the IP address and delete fqdn1 - so the foreman managed fqdn2 would never be cleaned up. 

