### PR TITLE
Use the smart_proxy_plugin.yml reusable GHA workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,5 @@ jobs:
   test:
     name: Tests
     needs: rubocop
-    uses: theforeman/actions/.github/workflows/test-gem.yml@v0
-    with:
-      command: bundle exec rake test
+    uses: theforeman/actions/.github/workflows/smart_proxy_plugin.yml@v0
 ...

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ on:  # yamllint disable-line rule:truthy
       - master
 
 concurrency:
-  group: ${{ github.ref_name }}
+  group: ${{ github.ref_name }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,6 @@ group :test do
   gem 'mocha'
   gem 'rack-test'
   gem 'rake'
-  gem 'smart_proxy', :github => 'theforeman/smart-proxy', :branch => 'develop'
+  gem 'smart_proxy', :github => 'theforeman/smart-proxy', :branch => ENV.fetch('SMART_PROXY_BRANCH', 'develop')
   gem 'test-unit'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ group :rubocop do
 end
 
 group :test do
-  gem 'ci_reporter_test_unit'
   gem 'mocha'
   gem 'rack-test'
   gem 'rake'

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require 'ci/reporter/rake/test_unit'
 require 'rake'
 require 'rake/testtask'
 require 'rubocop/rake_task'
@@ -15,9 +14,4 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.test_files = FileList['test/**/*_test.rb']
   t.verbose = true
-end
-
-namespace :jenkins do
-  desc nil # No description means it's not listed in rake -T
-  task :unit => ['ci:setup:testunit', :test]
 end

--- a/smart_proxy_dns_infoblox.gemspec
+++ b/smart_proxy_dns_infoblox.gemspec
@@ -3,7 +3,7 @@ require File.expand_path('lib/smart_proxy_dns_infoblox/dns_infoblox_version', __
 Gem::Specification.new do |s|
   s.name        = 'smart_proxy_dns_infoblox'
   s.version     = Proxy::Dns::Infoblox::VERSION
-  s.license     = 'GPL-3.0'
+  s.license     = 'GPL-3.0-only'
   s.authors     = ['Matthew Nicholson']
   s.email       = ['matthew.a.nicholson@gmail.com']
   s.homepage    = 'https://github.com/theforeman/smart_proxy_dns_infoblox'


### PR DESCRIPTION
This is largely the same as test-gem, except it verifies that it at least implements support for Ruby versions that the Smart Proxy wants. It also implements the version selector by respecting SMART_PROXY_BRANCH in the Gemfile.

Also cleans up Jenkins bits and updates the license tag.